### PR TITLE
Add Telegram reporting support to backup pipeline

### DIFF
--- a/Beta2/Run-Backup.ps1
+++ b/Beta2/Run-Backup.ps1
@@ -1,8 +1,35 @@
-﻿# Run-Backup.ps1
+# Run-Backup.ps1
 #requires -Version 5.1
 chcp 65001 > $null
 
 Write-Host "[INFO] Запуск процесса резервного копирования..." -ForegroundColor Yellow
+
+$modulesRoot = Join-Path $PSScriptRoot 'modules'
+Import-Module -Force -DisableNameChecking (Join-Path $modulesRoot 'Common.Crypto.psm1') -ErrorAction Stop
+Import-Module -Force -DisableNameChecking (Join-Path $modulesRoot 'Notifications.Telegram.psm1') -ErrorAction Stop
+
+function ConvertTo-HashtableCompat {
+    param([Parameter(Mandatory)]$Object)
+
+    if ($null -eq $Object) { return @{} }
+    if ($Object -is [hashtable]) { return $Object }
+
+    if ($Object -is [System.Collections.IDictionary]) {
+        $ht = @{}
+        foreach ($key in $Object.Keys) {
+            $ht[$key] = $Object[$key]
+        }
+        return $ht
+    }
+
+    $result = @{}
+    if ($Object.PSObject) {
+        foreach ($prop in $Object.PSObject.Properties) {
+            $result[$prop.Name] = $prop.Value
+        }
+    }
+    return $result
+}
 
 $pipelinePath = Join-Path $PSScriptRoot 'core\Pipeline.psm1'
 if (!(Test-Path $pipelinePath)) {
@@ -16,10 +43,48 @@ $basesDir   = Join-Path $configRoot 'bases'
 $logDir     = Join-Path $PSScriptRoot 'logs'
 if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir | Out-Null }
 
-$after = 3
 $settingsFile = Join-Path $configRoot 'settings.json'
+$settingsData = @{}
 if (Test-Path $settingsFile) {
-    try { $after = [int]((Get-Content $settingsFile -Raw | ConvertFrom-Json).AfterBackup) } catch { $after = 3 }
+    try {
+        $settingsData = ConvertTo-HashtableCompat (Get-Content $settingsFile -Raw | ConvertFrom-Json)
+    } catch { $settingsData = @{} }
+}
+
+$after = 3
+if ($settingsData.ContainsKey('AfterBackup')) {
+    try { $after = [int]$settingsData['AfterBackup'] } catch { $after = 3 }
+}
+
+$telegramConfig = @{}
+if ($settingsData.ContainsKey('Notifications')) {
+    $notifications = ConvertTo-HashtableCompat $settingsData['Notifications']
+    if ($notifications.ContainsKey('Telegram')) {
+        $telegramConfig = ConvertTo-HashtableCompat $notifications['Telegram']
+    }
+}
+
+$telegramEnabled = $false
+$telegramChatId  = ''
+$telegramSilent  = $false
+if ($telegramConfig.Count -gt 0) {
+    if ($telegramConfig.ContainsKey('Enabled')) { $telegramEnabled = [bool]$telegramConfig['Enabled'] }
+    if ($telegramConfig.ContainsKey('ChatId'))   { $telegramChatId  = "" + $telegramConfig['ChatId'] }
+    if ($telegramConfig.ContainsKey('DisableNotification')) { $telegramSilent = [bool]$telegramConfig['DisableNotification'] }
+}
+
+$telegramToken = $null
+$keyPath     = Join-Path $configRoot 'key.bin'
+$secretsPath = Join-Path $configRoot 'secrets.json.enc'
+if ($telegramEnabled -and (Test-Path $keyPath) -and (Test-Path $secretsPath)) {
+    try {
+        $allSecrets = ConvertTo-HashtableCompat (Decrypt-Secrets -InFile $secretsPath -KeyPath $keyPath)
+        if ($allSecrets.ContainsKey('__TelegramBotToken')) {
+            $telegramToken = [string]$allSecrets['__TelegramBotToken']
+        }
+    } catch {
+        $telegramToken = $null
+    }
 }
 
 $bases = Get-ChildItem -Path $basesDir -Filter *.json -ErrorAction SilentlyContinue | ForEach-Object { $_.BaseName }
@@ -37,7 +102,12 @@ function Write-Log {
     Write-Host $line
 }
 
+$results = @()
+
 foreach ($tag in $bases) {
+    $artifact = $null
+    $status   = 'Success'
+    $message  = ''
     try {
         $ctx = @{
             Tag        = $tag
@@ -45,10 +115,79 @@ foreach ($tag in $bases) {
             ConfigDir  = $basesDir
             Log        = { param($msg) Write-Log ("[{0}] {1}" -f $tag, $msg) }
         }
-        Invoke-Pipeline -Ctx $ctx
+        $artifact = Invoke-Pipeline -Ctx $ctx
     }
     catch {
-        Write-Log ("[ОШИБКА][{0}] {1}" -f $tag, $_.Exception.Message)
+        $errMessage = $_.Exception.Message
+        Write-Log ("[ОШИБКА][{0}] {1}" -f $tag, $errMessage)
+        $status  = 'Failed'
+        $message = $errMessage
+    }
+
+    if ($status -eq 'Success') {
+        if ($artifact) {
+            $fileName = Split-Path $artifact -Leaf
+            if ([string]::IsNullOrWhiteSpace($fileName)) {
+                $fileName = 'Успешно'
+            }
+            $message = $fileName
+        } else {
+            $status  = 'Skipped'
+            $message = 'Отключено в конфиге'
+        }
+    }
+
+    $results += [pscustomobject]@{
+        Tag      = $tag
+        Status   = $status
+        Message  = $message
+        Artifact = $artifact
+    }
+}
+
+if ($telegramEnabled) {
+    if (-not $telegramChatId) {
+        Write-Log "[WARN] Telegram-отчёт включён, но chat_id не задан."
+    }
+    elseif (-not $telegramToken) {
+        Write-Log "[WARN] Telegram-отчёт включён, но токен бота отсутствует или не расшифрован."
+    }
+    else {
+        $lines = @("Резервное копирование: $(Get-Date -Format 'dd.MM.yyyy HH:mm:ss')")
+        foreach ($result in $results) {
+            switch ($result.Status) {
+                'Success' {
+                    $lines += "✅ $($result.Tag) — $($result.Message)"
+                }
+                'Skipped' {
+                    $lines += "⚠️ $($result.Tag) — $($result.Message)"
+                }
+                default {
+                    $err = if ($result.Message) { [string]$result.Message } else { 'Сбой' }
+                    if ($err.Length -gt 200) { $err = $err.Substring(0,200) + '...' }
+                    $lines += "❌ $($result.Tag) — $err"
+                }
+            }
+        }
+
+        $actionLine = switch ($after) {
+            1 { 'Действие после завершения: выключение ПК' }
+            2 { 'Действие после завершения: перезагрузка ПК' }
+            default { 'Действие после завершения: без дополнительных действий' }
+        }
+        $lines += $actionLine
+
+        $text = $lines -join "`n"
+        try {
+            if ($telegramSilent) {
+                Send-TelegramMessage -Token $telegramToken -ChatId $telegramChatId -Text $text -DisableNotification
+            } else {
+                Send-TelegramMessage -Token $telegramToken -ChatId $telegramChatId -Text $text
+            }
+            Write-Log "[INFO] Отчёт отправлен в Telegram."
+        } catch {
+            Write-Log ("[ОШИБКА] Не удалось отправить отчёт в Telegram: {0}" -f $_.Exception.Message)
+        }
     }
 }
 

--- a/Beta2/modules/Notifications.Telegram.psm1
+++ b/Beta2/modules/Notifications.Telegram.psm1
@@ -1,0 +1,50 @@
+#requires -Version 5.1
+
+function Send-TelegramMessage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Token,
+        [Parameter(Mandatory)][string]$ChatId,
+        [Parameter(Mandatory)][string]$Text,
+        [switch]$DisableNotification
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Token)) {
+        throw "Token не задан"
+    }
+    if ([string]::IsNullOrWhiteSpace($ChatId)) {
+        throw "ChatId не задан"
+    }
+    if ($null -eq $Text) {
+        $Text = ''
+    }
+
+    $body = @{
+        chat_id = $ChatId
+        text    = [string]$Text
+    }
+    if ($DisableNotification.IsPresent) {
+        $body.disable_notification = $true
+    }
+
+    $url = "https://api.telegram.org/bot$Token/sendMessage"
+
+    $prevProto = [Net.ServicePointManager]::SecurityProtocol
+    try {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+    } catch {
+        # игнорируем, если невозможно установить протокол
+    }
+
+    try {
+        Invoke-RestMethod -Method Post -Uri $url -Body $body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop | Out-Null
+    }
+    catch {
+        throw "Не удалось отправить сообщение в Telegram: $($_.Exception.Message)"
+    }
+    finally {
+        try { [Net.ServicePointManager]::SecurityProtocol = $prevProto } catch {}
+    }
+}
+
+Export-ModuleMember -Function Send-TelegramMessage


### PR DESCRIPTION
## Summary
- add a reusable Notifications.Telegram module for posting messages through the Bot API
- extend the setup wizard to configure Telegram chat details, encrypt the bot token, and optionally send a test message
- enhance the backup runner to collect per-base results, send a Telegram summary, and tidy the disabled-base branch in the pipeline
- ensure JSON conversion helpers cope with generic IDictionary instances so encrypted secrets (including the Telegram bot token) decrypt reliably at runtime

## Testing
- `pwsh -NoLogo -NoProfile -Command "Import-Module .\core\Pipeline.psm1"` *(fails: pwsh not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc37936dfc8326b614e8b422e0be96